### PR TITLE
dns-he-net.eu.org zone fix

### DIFF
--- a/client/client/client_test.go
+++ b/client/client/client_test.go
@@ -39,12 +39,12 @@ func TestClientAuth(t *testing.T) {
 		zones, err := cli.GetZones(context.TODO())
 		require.NoError(t, err)
 
-		assert.Equal(t, 2, len(zones))
+		assert.Equal(t, 3, len(zones))
 
 		assert.Equal(t, "v6643873d8c41428.97783691", cli.GetAccount())
 
 		// Not onboarded record
-		records, err := cli.GetRecords(context.TODO(), 1091256)
+		records, err := cli.GetRecords(context.TODO(), 1096291)
 		require.Error(t, err)
 		assert.Nil(t, records)
 
@@ -69,9 +69,9 @@ func TestClientAuth(t *testing.T) {
 		zones, err := cli.GetZones(context.TODO())
 		require.NoError(t, err)
 
-		assert.Equal(t, 2, len(zones))
+		assert.Equal(t, 3, len(zones))
 
-		records, err := cli.GetRecords(context.TODO(), 1091256)
+		records, err := cli.GetRecords(context.TODO(), 1096291)
 		require.Error(t, err)
 		assert.Nil(t, records)
 	})

--- a/internal/datasources/zones_test.go
+++ b/internal/datasources/zones_test.go
@@ -20,7 +20,7 @@ func TestAccZones(t *testing.T) {
 				}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify record attibutes
-					resource.TestCheckResourceAttr("data.dns-he-net_zones.example", "zones.#", "2"),
+					resource.TestCheckResourceAttr("data.dns-he-net_zones.example", "zones.#", "3"),
 
 					// Verify placeholder attributes
 					resource.TestCheckResourceAttr("data.dns-he-net_zones.example", "id", "v6643873d8c41428.97783691"),


### PR DESCRIPTION
We got our new domain dns-he-net.eu.org approved.
This domain is provided by https://nic.eu.org/ and is being used on a first instance for destructive tests.