### PR TITLE
Removed DDNS support in AFSDB

### DIFF
--- a/client/models/README.md
+++ b/client/models/README.md
@@ -290,50 +290,49 @@ func (r AAAA) Serialise() map[string]string
 func (r AAAA) Type() string
 ```
 
-## type [AFSDB](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L5-L12>)
+## type [AFSDB](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L5-L11>)
 
 ```go
 type AFSDB struct {
-    ID      *uint
-    ZoneID  uint
-    Domain  string
-    TTL     uint // seconds
-    Data    string
-    Dynamic bool
+    ID     *uint
+    ZoneID uint
+    Domain string
+    TTL    uint // seconds
+    Data   string
 }
 ```
 
-### func [ToAFSDB](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L14>)
+### func [ToAFSDB](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L13>)
 
 ```go
 func ToAFSDB(r Record) AFSDB
 ```
 
-### func \(AFSDB\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L45>)
+### func \(AFSDB\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L42>)
 
 ```go
 func (r AFSDB) GetID() (uint, bool)
 ```
 
-### func \(AFSDB\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L53>)
+### func \(AFSDB\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L50>)
 
 ```go
 func (r AFSDB) GetZoneID() uint
 ```
 
-### func \(AFSDB\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L38>)
+### func \(AFSDB\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L35>)
 
 ```go
 func (r AFSDB) Refs() map[string]string
 ```
 
-### func \(AFSDB\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L25>)
+### func \(AFSDB\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L23>)
 
 ```go
 func (r AFSDB) Serialise() map[string]string
 ```
 
-### func \(AFSDB\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L57>)
+### func \(AFSDB\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L54>)
 
 ```go
 func (r AFSDB) Type() string

--- a/client/models/record_AFSDB.go
+++ b/client/models/record_AFSDB.go
@@ -3,22 +3,20 @@ package models
 import "fmt"
 
 type AFSDB struct {
-	ID      *uint
-	ZoneID  uint
-	Domain  string
-	TTL     uint // seconds
-	Data    string
-	Dynamic bool
+	ID     *uint
+	ZoneID uint
+	Domain string
+	TTL    uint // seconds
+	Data   string
 }
 
 func ToAFSDB(r Record) AFSDB {
 	return AFSDB{
-		ID:      r.ID,
-		ZoneID:  r.ZoneID,
-		Domain:  r.Domain,
-		TTL:     r.TTL,
-		Data:    r.Data,
-		Dynamic: r.Dynamic,
+		ID:     r.ID,
+		ZoneID: r.ZoneID,
+		Domain: r.Domain,
+		TTL:    r.TTL,
+		Data:   r.Data,
 	}
 }
 
@@ -31,7 +29,6 @@ func (r AFSDB) Serialise() map[string]string {
 		"Name":    r.Domain,
 		"Content": r.Data,
 		"TTL":     fmt.Sprint(r.TTL),
-		"dynamic": b2s[r.Dynamic],
 	}
 }
 

--- a/client/models/record_test.go
+++ b/client/models/record_test.go
@@ -62,7 +62,7 @@ var records_out = []models.RecordX{
 	models.CAA{ID: nil, ZoneID: 1234567, Domain: "example.com", TTL: 86400, Data: "0 iodef \"webmaster@example.com\""},
 	models.SRV{ID: nil, ZoneID: 1234567, Domain: "_https._tcp.example.com", TTL: 300, Priority: 0, Weight: 0, Port: 443, Target: "ff.example.com"},
 	models.TXT{ID: nil, ZoneID: 1234567, Domain: "txt.example.com", TTL: 86400, Data: "\"Some data 0\"", Dynamic: false},
-	models.AFSDB{ID: nil, ZoneID: 1234567, Domain: "example.com", TTL: 300, Data: "1 afsdb.example.com", Dynamic: false},
+	models.AFSDB{ID: nil, ZoneID: 1234567, Domain: "example.com", TTL: 300, Data: "1 afsdb.example.com"},
 	models.HINFO{ID: nil, ZoneID: 1234567, Domain: "example.com", TTL: 300, Data: "i686 Linux"},
 	models.RP{ID: nil, ZoneID: 1234567, Domain: "example.com", TTL: 300, Data: "user.example.com user.example.com"},
 	models.LOC{ID: nil, ZoneID: 1234567, Domain: "example.com", TTL: 300, Data: "51 56 0.123 N 5 54 0.000 E 4.00m 1.00m 10000.00m 10.00m"},

--- a/internal/datasources/AFSDB.go
+++ b/internal/datasources/AFSDB.go
@@ -62,11 +62,6 @@ func (afsdb) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasou
 				MarkdownDescription: "Value of the DNS record: *TODO*",
 				Computed:            true,
 			},
-			"dynamic": schema.BoolAttribute{
-				Description:         "Enable DDNS for this record",
-				MarkdownDescription: "Enable DDNS for this record",
-				Computed:            true,
-			},
 		},
 	}
 }

--- a/internal/datasources/AFSDB_test.go
+++ b/internal/datasources/AFSDB_test.go
@@ -26,7 +26,6 @@ func TestAccAFSDB(t *testing.T) {
 					resource.TestCheckResourceAttr("data.dns-he-net_afsdb.record-afsdb", "domain", "dns-he-net.ovh"),
 					resource.TestCheckResourceAttr("data.dns-he-net_afsdb.record-afsdb", "ttl", "300"),
 					resource.TestCheckResourceAttr("data.dns-he-net_afsdb.record-afsdb", "data", "2 green.dns-he-net.ovh"),
-					resource.TestCheckResourceAttr("data.dns-he-net_afsdb.record-afsdb", "dynamic", "true"),
 
 					// Verify placeholder attributes
 					resource.TestCheckResourceAttr("data.dns-he-net_afsdb.record-afsdb", "id", "5195520341"),

--- a/internal/datasources/README.md
+++ b/internal/datasources/README.md
@@ -688,7 +688,7 @@ type afsdb struct {
 }
 ```
 
-### func \(\*afsdb\) [Configure](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/internal/datasources/blob/master/internal/datasources/AFSDB.go#L75>)
+### func \(\*afsdb\) [Configure](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/internal/datasources/blob/master/internal/datasources/AFSDB.go#L70>)
 
 ```go
 func (d *afsdb) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse)
@@ -704,7 +704,7 @@ func (afsdb) Metadata(_ context.Context, req datasource.MetadataRequest, resp *d
 
 Metadata returns the data source type name.
 
-### func \(afsdb\) [Read](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/internal/datasources/blob/master/internal/datasources/AFSDB.go#L82>)
+### func \(afsdb\) [Read](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/internal/datasources/blob/master/internal/datasources/AFSDB.go#L77>)
 
 ```go
 func (d afsdb) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse)

--- a/internal/resources/AFSDB.go
+++ b/internal/resources/AFSDB.go
@@ -6,14 +6,11 @@ import (
 
 	"github.com/SuperBuker/terraform-provider-dns-he-net/client/client"
 	"github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
-	"github.com/SuperBuker/terraform-provider-dns-he-net/internal/planmodifiers"
 	"github.com/SuperBuker/terraform-provider-dns-he-net/internal/tfmodels"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -80,23 +77,12 @@ func (afsdb) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.
 				},
 			},
 			"data": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
+				Required:            true,
 				Description:         "Value of the DNS record: *TODO*",
 				MarkdownDescription: "Value of the DNS record: *TODO*",
 				Validators: []validator.String{
 					afsdbValidator,
 				},
-				PlanModifiers: []planmodifier.String{
-					planmodifiers.UseStateOrDftForUnknown("1 afsdb.example.com"),
-				},
-			},
-			"dynamic": schema.BoolAttribute{
-				Computed:            true, // Isn't really computed...
-				Optional:            true,
-				Description:         "Enable DDNS for this record",
-				MarkdownDescription: "Enable DDNS for this record",
-				Default:             booldefault.StaticBool(false),
 			},
 		},
 	}
@@ -285,43 +271,6 @@ func (r afsdb) Delete(ctx context.Context, req resource.DeleteRequest, resp *res
 			"Unable to delete AFSDB record",
 			err.Error(),
 		)
-	}
-}
-
-func (afsdb) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var config tfmodels.AFSDB
-
-	// Retrieve values from config
-	diags := req.Config.Get(ctx, &config)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	recordA, err := config.GetRecord()
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to build AFSDB record",
-			err.Error(),
-		)
-		return
-	}
-
-	// Validate configuration
-	if !config.Data.IsUnknown() && !config.Data.IsNull() {
-		// pass
-	} else if recordA.Dynamic {
-		resp.Diagnostics.AddAttributeWarning(
-			path.Root("data"),
-			"Missing Attribute Configuration",
-			"Applying default configuration",
-		)
-	} else {
-		resp.Diagnostics.AddError(
-			"Invalid AFSDB record configuration",
-			"Static AFSDB records must have Data configured.",
-		)
-		return
 	}
 }
 

--- a/internal/resources/AFSDB_test.go
+++ b/internal/resources/AFSDB_test.go
@@ -2,7 +2,6 @@ package resources_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/SuperBuker/terraform-provider-dns-he-net/internal/test_utils"
@@ -14,21 +13,9 @@ func TestAccAFSDBRecord(t *testing.T) {
 	domainInit := domains[0]
 	domainUpdate := domains[1]
 
-	password := randStringBytesMaskImprSrcSB(16)
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: test_utils.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Validate config
-			// Must fail because the default dynamic value is false and data is not set
-			{
-				Config: test_utils.ProviderConfig + fmt.Sprintf(`resource "dns-he-net_afsdb" "record-afsdb" {
-					zone_id = 1091256
-					domain = %q
-					ttl = 300
-				}`, domainInit),
-				ExpectError: regexp.MustCompile("Invalid AFSDB record configuration"),
-			},
 			// Create and Read testing
 			// Validates data default value by setting dynamic to true
 			{
@@ -36,15 +23,14 @@ func TestAccAFSDBRecord(t *testing.T) {
 					zone_id = 1091256
 					domain = %q
 					ttl = 300
-					dynamic = true
+					data = "1 green.dns-he-net.eu.org"
 				}`, domainInit),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify record attibutes
 					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "zone_id", "1091256"),
 					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "domain", domainInit),
 					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "ttl", "300"),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "data", "1 afsdb.example.com"),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "dynamic", "true"),
+					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "data", "1 green.dns-he-net.eu.org"),
 				),
 			},
 			// ImportState testing
@@ -62,65 +48,14 @@ func TestAccAFSDBRecord(t *testing.T) {
 					zone_id = 1091256
 					domain = %q
 					ttl = 600
-					data = "1 green.dns-he-net.eu.org"
+					data = "2 blue.dns-he-net.eu.org"
 				}`, domainUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify record attibutes
 					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "zone_id", "1091256"),
 					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "domain", domainUpdate),
 					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "ttl", "600"),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "data", "1 green.dns-he-net.eu.org"),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "dynamic", "false"),
-				),
-			},
-			// Update and Read testing
-			// Validates state continuity by setting dynamic to true and ommiting data
-			{
-				Config: test_utils.ProviderConfig + fmt.Sprintf(`resource "dns-he-net_afsdb" "record-afsdb" {
-					zone_id = 1091256
-					domain = %q
-					ttl = 600
-					dynamic = true
-				}
-
-				resource "dns-he-net_ddnskey" "ddnskey" {
-					domain = %q
-					zone_id = 1091256
-					key = %q
-				}`, domainUpdate, domainUpdate, password),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Verify record attibutes
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "zone_id", "1091256"),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "domain", domainUpdate),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "ttl", "600"),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "data", "1 green.dns-he-net.eu.org"),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "dynamic", "true"),
-				),
-			},
-			// Update and Read testing
-			// Update and Read testing
-			// Validates forcing a data value with dynamic set to true
-			{
-				Config: test_utils.ProviderConfig + fmt.Sprintf(`resource "dns-he-net_afsdb" "record-afsdb" {
-					zone_id = 1091256
-					domain = %q
-					ttl = 600
-					data = "1 green.dns-he-net.eu.org"
-					dynamic = true
-				}
-
-				resource "dns-he-net_ddnskey" "ddnskey" {
-					domain = %q
-					zone_id = 1091256
-					key = %q
-				}`, domainUpdate, domainUpdate, password),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Verify record attibutes
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "zone_id", "1091256"),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "domain", domainUpdate),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "ttl", "600"),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "data", "1 green.dns-he-net.eu.org"),
-					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "dynamic", "true"),
+					resource.TestCheckResourceAttr("dns-he-net_afsdb.record-afsdb", "data", "2 blue.dns-he-net.eu.org"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/tfmodels/AFSDB.go
+++ b/internal/tfmodels/AFSDB.go
@@ -8,12 +8,11 @@ import (
 
 // AFSDB maps the record schema data.
 type AFSDB struct {
-	ID      types.Int64  `tfsdk:"id"`
-	ZoneID  types.Int64  `tfsdk:"zone_id"`
-	Domain  types.String `tfsdk:"domain"`
-	TTL     types.Int64  `tfsdk:"ttl"`
-	Data    types.String `tfsdk:"data"`
-	Dynamic types.Bool   `tfsdk:"dynamic"`
+	ID     types.Int64  `tfsdk:"id"`
+	ZoneID types.Int64  `tfsdk:"zone_id"`
+	Domain types.String `tfsdk:"domain"`
+	TTL    types.Int64  `tfsdk:"ttl"`
+	Data   types.String `tfsdk:"data"`
 }
 
 func (afsdb *AFSDB) SetRecord(recordAFSDB models.AFSDB) error {
@@ -22,18 +21,16 @@ func (afsdb *AFSDB) SetRecord(recordAFSDB models.AFSDB) error {
 	afsdb.Domain = types.StringValue(recordAFSDB.Domain)
 	afsdb.TTL = types.Int64Value(int64(recordAFSDB.TTL))
 	afsdb.Data = types.StringValue(recordAFSDB.Data)
-	afsdb.Dynamic = types.BoolValue(recordAFSDB.Dynamic)
 
 	return nil
 }
 
 func (afsdb AFSDB) GetRecord() (models.AFSDB, error) {
 	return models.AFSDB{
-		ID:      utils.NativeUInt(afsdb.ID),
-		ZoneID:  uint(afsdb.ZoneID.ValueInt64()),
-		Domain:  afsdb.Domain.ValueString(),
-		TTL:     uint(afsdb.TTL.ValueInt64()),
-		Data:    afsdb.Data.ValueString(),
-		Dynamic: afsdb.Dynamic.ValueBool(),
+		ID:     utils.NativeUInt(afsdb.ID),
+		ZoneID: uint(afsdb.ZoneID.ValueInt64()),
+		Domain: afsdb.Domain.ValueString(),
+		TTL:    uint(afsdb.TTL.ValueInt64()),
+		Data:   afsdb.Data.ValueString(),
 	}, nil
 }

--- a/internal/tfmodels/AFSDB_test.go
+++ b/internal/tfmodels/AFSDB_test.go
@@ -12,12 +12,11 @@ func TestModelAFSDB(t *testing.T) {
 	id := uint(1)
 
 	expected := models.AFSDB{
-		ID:      &id,
-		ZoneID:  1,
-		Domain:  "example.com",
-		TTL:     300,
-		Data:    "2 green.example.com",
-		Dynamic: true,
+		ID:     &id,
+		ZoneID: 1,
+		Domain: "example.com",
+		TTL:    300,
+		Data:   "2 green.example.com",
 	}
 
 	afsdb := AFSDB{}

--- a/internal/tfmodels/README.md
+++ b/internal/tfmodels/README.md
@@ -129,28 +129,27 @@ func (aaaa AAAA) GetRecord() (models.AAAA, error)
 func (aaaa *AAAA) SetRecord(recordAAAA models.AAAA) error
 ```
 
-## type [AFSDB](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/internal/tfmodels/blob/master/internal/tfmodels/AFSDB.go#L10-L17>)
+## type [AFSDB](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/internal/tfmodels/blob/master/internal/tfmodels/AFSDB.go#L10-L16>)
 
 AFSDB maps the record schema data.
 
 ```go
 type AFSDB struct {
-    ID      types.Int64  `tfsdk:"id"`
-    ZoneID  types.Int64  `tfsdk:"zone_id"`
-    Domain  types.String `tfsdk:"domain"`
-    TTL     types.Int64  `tfsdk:"ttl"`
-    Data    types.String `tfsdk:"data"`
-    Dynamic types.Bool   `tfsdk:"dynamic"`
+    ID     types.Int64  `tfsdk:"id"`
+    ZoneID types.Int64  `tfsdk:"zone_id"`
+    Domain types.String `tfsdk:"domain"`
+    TTL    types.Int64  `tfsdk:"ttl"`
+    Data   types.String `tfsdk:"data"`
 }
 ```
 
-### func \(AFSDB\) [GetRecord](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/internal/tfmodels/blob/master/internal/tfmodels/AFSDB.go#L30>)
+### func \(AFSDB\) [GetRecord](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/internal/tfmodels/blob/master/internal/tfmodels/AFSDB.go#L28>)
 
 ```go
 func (afsdb AFSDB) GetRecord() (models.AFSDB, error)
 ```
 
-### func \(\*AFSDB\) [SetRecord](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/internal/tfmodels/blob/master/internal/tfmodels/AFSDB.go#L19>)
+### func \(\*AFSDB\) [SetRecord](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/internal/tfmodels/blob/master/internal/tfmodels/AFSDB.go#L18>)
 
 ```go
 func (afsdb *AFSDB) SetRecord(recordAFSDB models.AFSDB) error


### PR DESCRIPTION
Removing support for DDNS in AFSDB.

As described in [HE NET Forums](https://forums.he.net/index.php?topic=4255.0), this feature is not supported.