### PR TITLE
Record match fix

### DIFF
--- a/client/client/filters/README.md
+++ b/client/client/filters/README.md
@@ -10,13 +10,14 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/client/filter
 
 - [func LatestRecord(records []models.Record) (r models.Record, ok bool)](<#func-latestrecord>)
 - [func LatestZone(zones []models.Zone) (d models.Zone, ok bool)](<#func-latestzone>)
+- [func MatchRecord(records []models.Record, rx models.RecordX) (r models.Record, ok bool)](<#func-matchrecord>)
 - [func Record(records []models.Record, domain *string, typ *string) []models.Record](<#func-record>)
 - [func RecordById(records []models.Record, id uint) (models.Record, bool)](<#func-recordbyid>)
 - [func ZoneById(zones []models.Zone, id uint) (models.Zone, bool)](<#func-zonebyid>)
 - [func ZoneByName(zones []models.Zone, name string) (models.Zone, bool)](<#func-zonebyname>)
 
 
-## func [LatestRecord](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/client/filters/blob/master/client/client/filters/records.go#L24>)
+## func [LatestRecord](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/client/filters/blob/master/client/client/filters/records.go#L37>)
 
 ```go
 func LatestRecord(records []models.Record) (r models.Record, ok bool)
@@ -32,7 +33,15 @@ func LatestZone(zones []models.Zone) (d models.Zone, ok bool)
 
 LatestZone returns the latest zone \(highest ID\) in a slice of zones. If the slice is empty, it returns an empty string and false.
 
-## func [Record](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/client/filters/blob/master/client/client/filters/records.go#L44>)
+## func [MatchRecord](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/client/filters/blob/master/client/client/filters/records.go#L24>)
+
+```go
+func MatchRecord(records []models.Record, rx models.RecordX) (r models.Record, ok bool)
+```
+
+MatchRecord returns the record matching the input in a slice of records. If the slice doesn't contain any matching record, it returns an empty record and false.
+
+## func [Record](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/client/filters/blob/master/client/client/filters/records.go#L57>)
 
 ```go
 func Record(records []models.Record, domain *string, typ *string) []models.Record

--- a/client/client/filters/records.go
+++ b/client/client/filters/records.go
@@ -18,6 +18,19 @@ func RecordById(records []models.Record, id uint) (models.Record, bool) {
 	return models.Record{}, false
 }
 
+// MatchRecord returns the record matching the input in a slice of records.
+// If the slice doesn't contain any matching record, it returns an empty record
+// and false.
+func MatchRecord(records []models.Record, rx models.RecordX) (r models.Record, ok bool) {
+	for _, record := range records {
+		if rx.Equals(record) {
+			return record, true
+		}
+	}
+
+	return models.Record{}, false
+}
+
 // LatestRecord returns the latest record (highest ID) in a slice of records.
 // If the slice doesn't contain any record with ID, it returns an empty record
 // and false.

--- a/client/client/filters/records_test.go
+++ b/client/client/filters/records_test.go
@@ -49,6 +49,14 @@ func TestRecordById(t *testing.T) {
 	}
 }
 
+func TestMatchRecord(t *testing.T) {
+	for i, record := range records {
+		rec, ok := filters.MatchRecord(records, record)
+		assert.True(t, ok)
+		assert.Equal(t, records[i], rec)
+	}
+}
+
 func TestLatestRecord(t *testing.T) {
 	record, ok := filters.LatestRecord(records)
 	assert.Equal(t, records[9], record)

--- a/client/client/records.go
+++ b/client/client/records.go
@@ -68,7 +68,7 @@ func (c *Client) SetRecord(ctx context.Context, record models.RecordX) (models.R
 	}
 
 	if !idIsSet {
-		_record, ok := filters.LatestRecord(records)
+		_record, ok := filters.MatchRecord(records, record)
 
 		if !ok {
 			return nil, &ErrItemNotFound{Resource: "record"} // TODO: to improve

--- a/client/models/README.md
+++ b/client/models/README.md
@@ -14,6 +14,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
 - [func toString(n interface{}) string](<#func-tostring>)
 - [type A](<#type-a>)
   - [func ToA(r Record) A](<#func-toa>)
+  - [func (r A) Equals(rx RecordX) bool](<#func-a-equals>)
   - [func (r A) GetID() (uint, bool)](<#func-a-getid>)
   - [func (r A) GetZoneID() uint](<#func-a-getzoneid>)
   - [func (r A) Refs() map[string]string](<#func-a-refs>)
@@ -21,6 +22,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r A) Type() string](<#func-a-type>)
 - [type AAAA](<#type-aaaa>)
   - [func ToAAAA(r Record) AAAA](<#func-toaaaa>)
+  - [func (r AAAA) Equals(rx RecordX) bool](<#func-aaaa-equals>)
   - [func (r AAAA) GetID() (uint, bool)](<#func-aaaa-getid>)
   - [func (r AAAA) GetZoneID() uint](<#func-aaaa-getzoneid>)
   - [func (r AAAA) Refs() map[string]string](<#func-aaaa-refs>)
@@ -28,6 +30,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r AAAA) Type() string](<#func-aaaa-type>)
 - [type AFSDB](<#type-afsdb>)
   - [func ToAFSDB(r Record) AFSDB](<#func-toafsdb>)
+  - [func (r AFSDB) Equals(rx RecordX) bool](<#func-afsdb-equals>)
   - [func (r AFSDB) GetID() (uint, bool)](<#func-afsdb-getid>)
   - [func (r AFSDB) GetZoneID() uint](<#func-afsdb-getzoneid>)
   - [func (r AFSDB) Refs() map[string]string](<#func-afsdb-refs>)
@@ -35,6 +38,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r AFSDB) Type() string](<#func-afsdb-type>)
 - [type ALIAS](<#type-alias>)
   - [func ToALIAS(r Record) ALIAS](<#func-toalias>)
+  - [func (r ALIAS) Equals(rx RecordX) bool](<#func-alias-equals>)
   - [func (r ALIAS) GetID() (uint, bool)](<#func-alias-getid>)
   - [func (r ALIAS) GetZoneID() uint](<#func-alias-getzoneid>)
   - [func (r ALIAS) Refs() map[string]string](<#func-alias-refs>)
@@ -42,6 +46,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r ALIAS) Type() string](<#func-alias-type>)
 - [type CAA](<#type-caa>)
   - [func ToCAA(r Record) CAA](<#func-tocaa>)
+  - [func (r CAA) Equals(rx RecordX) bool](<#func-caa-equals>)
   - [func (r CAA) GetID() (uint, bool)](<#func-caa-getid>)
   - [func (r CAA) GetZoneID() uint](<#func-caa-getzoneid>)
   - [func (r CAA) Refs() map[string]string](<#func-caa-refs>)
@@ -49,6 +54,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r CAA) Type() string](<#func-caa-type>)
 - [type CNAME](<#type-cname>)
   - [func ToCNAME(r Record) CNAME](<#func-tocname>)
+  - [func (r CNAME) Equals(rx RecordX) bool](<#func-cname-equals>)
   - [func (r CNAME) GetID() (uint, bool)](<#func-cname-getid>)
   - [func (r CNAME) GetZoneID() uint](<#func-cname-getzoneid>)
   - [func (r CNAME) Refs() map[string]string](<#func-cname-refs>)
@@ -63,6 +69,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (e *ErrFormat) Error() string](<#func-errformat-error>)
 - [type HINFO](<#type-hinfo>)
   - [func ToHINFO(r Record) HINFO](<#func-tohinfo>)
+  - [func (r HINFO) Equals(rx RecordX) bool](<#func-hinfo-equals>)
   - [func (r HINFO) GetID() (uint, bool)](<#func-hinfo-getid>)
   - [func (r HINFO) GetZoneID() uint](<#func-hinfo-getzoneid>)
   - [func (r HINFO) Refs() map[string]string](<#func-hinfo-refs>)
@@ -70,6 +77,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r HINFO) Type() string](<#func-hinfo-type>)
 - [type LOC](<#type-loc>)
   - [func ToLOC(r Record) LOC](<#func-toloc>)
+  - [func (r LOC) Equals(rx RecordX) bool](<#func-loc-equals>)
   - [func (r LOC) GetID() (uint, bool)](<#func-loc-getid>)
   - [func (r LOC) GetZoneID() uint](<#func-loc-getzoneid>)
   - [func (r LOC) Refs() map[string]string](<#func-loc-refs>)
@@ -77,6 +85,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r LOC) Type() string](<#func-loc-type>)
 - [type MX](<#type-mx>)
   - [func ToMX(r Record) (MX, error)](<#func-tomx>)
+  - [func (r MX) Equals(rx RecordX) bool](<#func-mx-equals>)
   - [func (r MX) GetID() (uint, bool)](<#func-mx-getid>)
   - [func (r MX) GetZoneID() uint](<#func-mx-getzoneid>)
   - [func (r MX) Refs() map[string]string](<#func-mx-refs>)
@@ -84,6 +93,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r MX) Type() string](<#func-mx-type>)
 - [type NAPTR](<#type-naptr>)
   - [func ToNAPTR(r Record) NAPTR](<#func-tonaptr>)
+  - [func (r NAPTR) Equals(rx RecordX) bool](<#func-naptr-equals>)
   - [func (r NAPTR) GetID() (uint, bool)](<#func-naptr-getid>)
   - [func (r NAPTR) GetZoneID() uint](<#func-naptr-getzoneid>)
   - [func (r NAPTR) Refs() map[string]string](<#func-naptr-refs>)
@@ -91,6 +101,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r NAPTR) Type() string](<#func-naptr-type>)
 - [type NS](<#type-ns>)
   - [func ToNS(r Record) NS](<#func-tons>)
+  - [func (r NS) Equals(rx RecordX) bool](<#func-ns-equals>)
   - [func (r NS) GetID() (uint, bool)](<#func-ns-getid>)
   - [func (r NS) GetZoneID() uint](<#func-ns-getzoneid>)
   - [func (r NS) Refs() map[string]string](<#func-ns-refs>)
@@ -98,6 +109,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r NS) Type() string](<#func-ns-type>)
 - [type PTR](<#type-ptr>)
   - [func ToPTR(r Record) PTR](<#func-toptr>)
+  - [func (r PTR) Equals(rx RecordX) bool](<#func-ptr-equals>)
   - [func (r PTR) GetID() (uint, bool)](<#func-ptr-getid>)
   - [func (r PTR) GetZoneID() uint](<#func-ptr-getzoneid>)
   - [func (r PTR) Refs() map[string]string](<#func-ptr-refs>)
@@ -105,19 +117,25 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r PTR) Type() string](<#func-ptr-type>)
 - [type RP](<#type-rp>)
   - [func ToRP(r Record) RP](<#func-torp>)
+  - [func (r RP) Equals(rx RecordX) bool](<#func-rp-equals>)
   - [func (r RP) GetID() (uint, bool)](<#func-rp-getid>)
   - [func (r RP) GetZoneID() uint](<#func-rp-getzoneid>)
   - [func (r RP) Refs() map[string]string](<#func-rp-refs>)
   - [func (r RP) Serialise() map[string]string](<#func-rp-serialise>)
   - [func (r RP) Type() string](<#func-rp-type>)
 - [type Record](<#type-record>)
+  - [func (r Record) Equals(rx RecordX) bool](<#func-record-equals>)
+  - [func (r Record) GetID() (uint, bool)](<#func-record-getid>)
+  - [func (r Record) GetZoneID() uint](<#func-record-getzoneid>)
   - [func (r Record) Refs() map[string]string](<#func-record-refs>)
   - [func (r Record) Serialise() map[string]string](<#func-record-serialise>)
   - [func (r Record) ToX() (RecordX, error)](<#func-record-tox>)
+  - [func (r Record) Type() string](<#func-record-type>)
 - [type RecordX](<#type-recordx>)
 - [type SOA](<#type-soa>)
   - [func ToSOA(r Record) (SOA, error)](<#func-tosoa>)
   - [func parseSOAData(data string) (SOA, error)](<#func-parsesoadata>)
+  - [func (r SOA) Equals(rx RecordX) bool](<#func-soa-equals>)
   - [func (r SOA) GetID() (uint, bool)](<#func-soa-getid>)
   - [func (r SOA) GetZoneID() uint](<#func-soa-getzoneid>)
   - [func (r SOA) Refs() map[string]string](<#func-soa-refs>)
@@ -125,6 +143,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r SOA) Type() string](<#func-soa-type>)
 - [type SPF](<#type-spf>)
   - [func ToSPF(r Record) SPF](<#func-tospf>)
+  - [func (r SPF) Equals(rx RecordX) bool](<#func-spf-equals>)
   - [func (r SPF) GetID() (uint, bool)](<#func-spf-getid>)
   - [func (r SPF) GetZoneID() uint](<#func-spf-getzoneid>)
   - [func (r SPF) Refs() map[string]string](<#func-spf-refs>)
@@ -133,6 +152,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
 - [type SRV](<#type-srv>)
   - [func ToSRV(r Record) (SRV, error)](<#func-tosrv>)
   - [func parseSRVData(data string) (SRV, error)](<#func-parsesrvdata>)
+  - [func (r SRV) Equals(rx RecordX) bool](<#func-srv-equals>)
   - [func (r SRV) GetID() (uint, bool)](<#func-srv-getid>)
   - [func (r SRV) GetZoneID() uint](<#func-srv-getzoneid>)
   - [func (r SRV) Refs() map[string]string](<#func-srv-refs>)
@@ -140,6 +160,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
   - [func (r SRV) Type() string](<#func-srv-type>)
 - [type SSHFP](<#type-sshfp>)
   - [func ToSSHFP(r Record) SSHFP](<#func-tosshfp>)
+  - [func (r SSHFP) Equals(rx RecordX) bool](<#func-sshfp-equals>)
   - [func (r SSHFP) GetID() (uint, bool)](<#func-sshfp-getid>)
   - [func (r SSHFP) GetZoneID() uint](<#func-sshfp-getzoneid>)
   - [func (r SSHFP) Refs() map[string]string](<#func-sshfp-refs>)
@@ -148,6 +169,7 @@ import "github.com/SuperBuker/terraform-provider-dns-he-net/client/models"
 - [type StatusMessage](<#type-statusmessage>)
 - [type TXT](<#type-txt>)
   - [func ToTXT(r Record) TXT](<#func-totxt>)
+  - [func (r TXT) Equals(rx RecordX) bool](<#func-txt-equals>)
   - [func (r TXT) GetID() (uint, bool)](<#func-txt-getid>)
   - [func (r TXT) GetZoneID() uint](<#func-txt-getzoneid>)
   - [func (r TXT) Refs() map[string]string](<#func-txt-refs>)
@@ -211,31 +233,37 @@ type A struct {
 func ToA(r Record) A
 ```
 
-### func \(A\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L45>)
+### func \(A\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L25>)
+
+```go
+func (r A) Equals(rx RecordX) bool
+```
+
+### func \(A\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L64>)
 
 ```go
 func (r A) GetID() (uint, bool)
 ```
 
-### func \(A\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L53>)
+### func \(A\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L72>)
 
 ```go
 func (r A) GetZoneID() uint
 ```
 
-### func \(A\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L38>)
+### func \(A\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L57>)
 
 ```go
 func (r A) Refs() map[string]string
 ```
 
-### func \(A\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L25>)
+### func \(A\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L44>)
 
 ```go
 func (r A) Serialise() map[string]string
 ```
 
-### func \(A\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L57>)
+### func \(A\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_A.go#L76>)
 
 ```go
 func (r A) Type() string
@@ -260,31 +288,37 @@ type AAAA struct {
 func ToAAAA(r Record) AAAA
 ```
 
-### func \(AAAA\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L45>)
+### func \(AAAA\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L25>)
+
+```go
+func (r AAAA) Equals(rx RecordX) bool
+```
+
+### func \(AAAA\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L64>)
 
 ```go
 func (r AAAA) GetID() (uint, bool)
 ```
 
-### func \(AAAA\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L53>)
+### func \(AAAA\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L72>)
 
 ```go
 func (r AAAA) GetZoneID() uint
 ```
 
-### func \(AAAA\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L38>)
+### func \(AAAA\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L57>)
 
 ```go
 func (r AAAA) Refs() map[string]string
 ```
 
-### func \(AAAA\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L25>)
+### func \(AAAA\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L44>)
 
 ```go
 func (r AAAA) Serialise() map[string]string
 ```
 
-### func \(AAAA\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L57>)
+### func \(AAAA\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AAAA.go#L76>)
 
 ```go
 func (r AAAA) Type() string
@@ -308,31 +342,37 @@ type AFSDB struct {
 func ToAFSDB(r Record) AFSDB
 ```
 
-### func \(AFSDB\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L42>)
+### func \(AFSDB\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L23>)
+
+```go
+func (r AFSDB) Equals(rx RecordX) bool
+```
+
+### func \(AFSDB\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L60>)
 
 ```go
 func (r AFSDB) GetID() (uint, bool)
 ```
 
-### func \(AFSDB\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L50>)
+### func \(AFSDB\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L68>)
 
 ```go
 func (r AFSDB) GetZoneID() uint
 ```
 
-### func \(AFSDB\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L35>)
+### func \(AFSDB\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L53>)
 
 ```go
 func (r AFSDB) Refs() map[string]string
 ```
 
-### func \(AFSDB\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L23>)
+### func \(AFSDB\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L41>)
 
 ```go
 func (r AFSDB) Serialise() map[string]string
 ```
 
-### func \(AFSDB\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L54>)
+### func \(AFSDB\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_AFSDB.go#L72>)
 
 ```go
 func (r AFSDB) Type() string
@@ -356,31 +396,37 @@ type ALIAS struct {
 func ToALIAS(r Record) ALIAS
 ```
 
-### func \(ALIAS\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L42>)
+### func \(ALIAS\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L23>)
+
+```go
+func (r ALIAS) Equals(rx RecordX) bool
+```
+
+### func \(ALIAS\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L60>)
 
 ```go
 func (r ALIAS) GetID() (uint, bool)
 ```
 
-### func \(ALIAS\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L50>)
+### func \(ALIAS\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L68>)
 
 ```go
 func (r ALIAS) GetZoneID() uint
 ```
 
-### func \(ALIAS\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L35>)
+### func \(ALIAS\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L53>)
 
 ```go
 func (r ALIAS) Refs() map[string]string
 ```
 
-### func \(ALIAS\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L23>)
+### func \(ALIAS\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L41>)
 
 ```go
 func (r ALIAS) Serialise() map[string]string
 ```
 
-### func \(ALIAS\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L54>)
+### func \(ALIAS\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_ALIAS.go#L72>)
 
 ```go
 func (r ALIAS) Type() string
@@ -404,31 +450,37 @@ type CAA struct {
 func ToCAA(r Record) CAA
 ```
 
-### func \(CAA\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L42>)
+### func \(CAA\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L23>)
+
+```go
+func (r CAA) Equals(rx RecordX) bool
+```
+
+### func \(CAA\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L60>)
 
 ```go
 func (r CAA) GetID() (uint, bool)
 ```
 
-### func \(CAA\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L50>)
+### func \(CAA\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L68>)
 
 ```go
 func (r CAA) GetZoneID() uint
 ```
 
-### func \(CAA\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L35>)
+### func \(CAA\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L53>)
 
 ```go
 func (r CAA) Refs() map[string]string
 ```
 
-### func \(CAA\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L23>)
+### func \(CAA\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L41>)
 
 ```go
 func (r CAA) Serialise() map[string]string
 ```
 
-### func \(CAA\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L54>)
+### func \(CAA\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CAA.go#L72>)
 
 ```go
 func (r CAA) Type() string
@@ -452,31 +504,37 @@ type CNAME struct {
 func ToCNAME(r Record) CNAME
 ```
 
-### func \(CNAME\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L42>)
+### func \(CNAME\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L23>)
+
+```go
+func (r CNAME) Equals(rx RecordX) bool
+```
+
+### func \(CNAME\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L60>)
 
 ```go
 func (r CNAME) GetID() (uint, bool)
 ```
 
-### func \(CNAME\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L50>)
+### func \(CNAME\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L68>)
 
 ```go
 func (r CNAME) GetZoneID() uint
 ```
 
-### func \(CNAME\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L35>)
+### func \(CNAME\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L53>)
 
 ```go
 func (r CNAME) Refs() map[string]string
 ```
 
-### func \(CNAME\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L23>)
+### func \(CNAME\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L41>)
 
 ```go
 func (r CNAME) Serialise() map[string]string
 ```
 
-### func \(CNAME\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L54>)
+### func \(CNAME\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_CNAME.go#L72>)
 
 ```go
 func (r CNAME) Type() string
@@ -549,31 +607,37 @@ type HINFO struct {
 func ToHINFO(r Record) HINFO
 ```
 
-### func \(HINFO\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L42>)
+### func \(HINFO\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L23>)
+
+```go
+func (r HINFO) Equals(rx RecordX) bool
+```
+
+### func \(HINFO\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L60>)
 
 ```go
 func (r HINFO) GetID() (uint, bool)
 ```
 
-### func \(HINFO\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L50>)
+### func \(HINFO\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L68>)
 
 ```go
 func (r HINFO) GetZoneID() uint
 ```
 
-### func \(HINFO\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L35>)
+### func \(HINFO\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L53>)
 
 ```go
 func (r HINFO) Refs() map[string]string
 ```
 
-### func \(HINFO\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L23>)
+### func \(HINFO\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L41>)
 
 ```go
 func (r HINFO) Serialise() map[string]string
 ```
 
-### func \(HINFO\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L54>)
+### func \(HINFO\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_HINFO.go#L72>)
 
 ```go
 func (r HINFO) Type() string
@@ -597,31 +661,37 @@ type LOC struct {
 func ToLOC(r Record) LOC
 ```
 
-### func \(LOC\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L42>)
+### func \(LOC\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L23>)
+
+```go
+func (r LOC) Equals(rx RecordX) bool
+```
+
+### func \(LOC\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L60>)
 
 ```go
 func (r LOC) GetID() (uint, bool)
 ```
 
-### func \(LOC\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L50>)
+### func \(LOC\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L68>)
 
 ```go
 func (r LOC) GetZoneID() uint
 ```
 
-### func \(LOC\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L35>)
+### func \(LOC\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L53>)
 
 ```go
 func (r LOC) Refs() map[string]string
 ```
 
-### func \(LOC\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L23>)
+### func \(LOC\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L41>)
 
 ```go
 func (r LOC) Serialise() map[string]string
 ```
 
-### func \(LOC\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L54>)
+### func \(LOC\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_LOC.go#L72>)
 
 ```go
 func (r LOC) Type() string
@@ -646,31 +716,37 @@ type MX struct {
 func ToMX(r Record) (MX, error)
 ```
 
-### func \(MX\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L50>)
+### func \(MX\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L31>)
+
+```go
+func (r MX) Equals(rx RecordX) bool
+```
+
+### func \(MX\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L74>)
 
 ```go
 func (r MX) GetID() (uint, bool)
 ```
 
-### func \(MX\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L58>)
+### func \(MX\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L82>)
 
 ```go
 func (r MX) GetZoneID() uint
 ```
 
-### func \(MX\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L43>)
+### func \(MX\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L67>)
 
 ```go
 func (r MX) Refs() map[string]string
 ```
 
-### func \(MX\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L31>)
+### func \(MX\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L55>)
 
 ```go
 func (r MX) Serialise() map[string]string
 ```
 
-### func \(MX\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L62>)
+### func \(MX\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_MX.go#L86>)
 
 ```go
 func (r MX) Type() string
@@ -694,31 +770,37 @@ type NAPTR struct {
 func ToNAPTR(r Record) NAPTR
 ```
 
-### func \(NAPTR\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L42>)
+### func \(NAPTR\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L23>)
+
+```go
+func (r NAPTR) Equals(rx RecordX) bool
+```
+
+### func \(NAPTR\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L60>)
 
 ```go
 func (r NAPTR) GetID() (uint, bool)
 ```
 
-### func \(NAPTR\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L50>)
+### func \(NAPTR\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L68>)
 
 ```go
 func (r NAPTR) GetZoneID() uint
 ```
 
-### func \(NAPTR\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L35>)
+### func \(NAPTR\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L53>)
 
 ```go
 func (r NAPTR) Refs() map[string]string
 ```
 
-### func \(NAPTR\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L23>)
+### func \(NAPTR\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L41>)
 
 ```go
 func (r NAPTR) Serialise() map[string]string
 ```
 
-### func \(NAPTR\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L54>)
+### func \(NAPTR\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NAPTR.go#L72>)
 
 ```go
 func (r NAPTR) Type() string
@@ -742,31 +824,37 @@ type NS struct {
 func ToNS(r Record) NS
 ```
 
-### func \(NS\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L42>)
+### func \(NS\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L23>)
+
+```go
+func (r NS) Equals(rx RecordX) bool
+```
+
+### func \(NS\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L60>)
 
 ```go
 func (r NS) GetID() (uint, bool)
 ```
 
-### func \(NS\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L50>)
+### func \(NS\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L68>)
 
 ```go
 func (r NS) GetZoneID() uint
 ```
 
-### func \(NS\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L35>)
+### func \(NS\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L53>)
 
 ```go
 func (r NS) Refs() map[string]string
 ```
 
-### func \(NS\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L23>)
+### func \(NS\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L41>)
 
 ```go
 func (r NS) Serialise() map[string]string
 ```
 
-### func \(NS\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L53>)
+### func \(NS\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_NS.go#L71>)
 
 ```go
 func (r NS) Type() string
@@ -790,31 +878,37 @@ type PTR struct {
 func ToPTR(r Record) PTR
 ```
 
-### func \(PTR\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L42>)
+### func \(PTR\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L23>)
+
+```go
+func (r PTR) Equals(rx RecordX) bool
+```
+
+### func \(PTR\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L60>)
 
 ```go
 func (r PTR) GetID() (uint, bool)
 ```
 
-### func \(PTR\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L50>)
+### func \(PTR\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L68>)
 
 ```go
 func (r PTR) GetZoneID() uint
 ```
 
-### func \(PTR\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L35>)
+### func \(PTR\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L53>)
 
 ```go
 func (r PTR) Refs() map[string]string
 ```
 
-### func \(PTR\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L23>)
+### func \(PTR\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L41>)
 
 ```go
 func (r PTR) Serialise() map[string]string
 ```
 
-### func \(PTR\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L54>)
+### func \(PTR\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_PTR.go#L72>)
 
 ```go
 func (r PTR) Type() string
@@ -838,31 +932,37 @@ type RP struct {
 func ToRP(r Record) RP
 ```
 
-### func \(RP\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L42>)
+### func \(RP\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L23>)
+
+```go
+func (r RP) Equals(rx RecordX) bool
+```
+
+### func \(RP\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L60>)
 
 ```go
 func (r RP) GetID() (uint, bool)
 ```
 
-### func \(RP\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L50>)
+### func \(RP\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L68>)
 
 ```go
 func (r RP) GetZoneID() uint
 ```
 
-### func \(RP\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L35>)
+### func \(RP\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L53>)
 
 ```go
 func (r RP) Refs() map[string]string
 ```
 
-### func \(RP\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L23>)
+### func \(RP\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L41>)
 
 ```go
 func (r RP) Serialise() map[string]string
 ```
 
-### func \(RP\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L54>)
+### func \(RP\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_RP.go#L72>)
 
 ```go
 func (r RP) Type() string
@@ -884,13 +984,31 @@ type Record struct {
 }
 ```
 
-### func \(Record\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record.go#L67>)
+### func \(Record\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record.go#L59>)
+
+```go
+func (r Record) Equals(rx RecordX) bool
+```
+
+### func \(Record\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record.go#L87>)
+
+```go
+func (r Record) GetID() (uint, bool)
+```
+
+### func \(Record\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record.go#L95>)
+
+```go
+func (r Record) GetZoneID() uint
+```
+
+### func \(Record\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record.go#L79>)
 
 ```go
 func (r Record) Refs() map[string]string
 ```
 
-### func \(Record\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record.go#L59>)
+### func \(Record\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record.go#L71>)
 
 ```go
 func (r Record) Serialise() map[string]string
@@ -902,10 +1020,17 @@ func (r Record) Serialise() map[string]string
 func (r Record) ToX() (RecordX, error)
 ```
 
-## type [RecordX](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/interface.go#L3-L9>)
+### func \(Record\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record.go#L99>)
+
+```go
+func (r Record) Type() string
+```
+
+## type [RecordX](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/interface.go#L3-L10>)
 
 ```go
 type RecordX interface {
+    Equals(RecordX) bool
     GetID() (uint, bool)
     GetZoneID() uint
     Refs() map[string]string
@@ -943,31 +1068,37 @@ func ToSOA(r Record) (SOA, error)
 func parseSOAData(data string) (SOA, error)
 ```
 
-### func \(SOA\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L84>)
+### func \(SOA\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L65>)
+
+```go
+func (r SOA) Equals(rx RecordX) bool
+```
+
+### func \(SOA\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L112>)
 
 ```go
 func (r SOA) GetID() (uint, bool)
 ```
 
-### func \(SOA\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L92>)
+### func \(SOA\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L120>)
 
 ```go
 func (r SOA) GetZoneID() uint
 ```
 
-### func \(SOA\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L77>)
+### func \(SOA\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L105>)
 
 ```go
 func (r SOA) Refs() map[string]string
 ```
 
-### func \(SOA\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L65>)
+### func \(SOA\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L93>)
 
 ```go
 func (r SOA) Serialise() map[string]string
 ```
 
-### func \(SOA\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L96>)
+### func \(SOA\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SOA.go#L124>)
 
 ```go
 func (r SOA) Type() string
@@ -991,31 +1122,37 @@ type SPF struct {
 func ToSPF(r Record) SPF
 ```
 
-### func \(SPF\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L42>)
+### func \(SPF\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L23>)
+
+```go
+func (r SPF) Equals(rx RecordX) bool
+```
+
+### func \(SPF\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L60>)
 
 ```go
 func (r SPF) GetID() (uint, bool)
 ```
 
-### func \(SPF\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L50>)
+### func \(SPF\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L68>)
 
 ```go
 func (r SPF) GetZoneID() uint
 ```
 
-### func \(SPF\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L35>)
+### func \(SPF\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L53>)
 
 ```go
 func (r SPF) Refs() map[string]string
 ```
 
-### func \(SPF\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L23>)
+### func \(SPF\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L41>)
 
 ```go
 func (r SPF) Serialise() map[string]string
 ```
 
-### func \(SPF\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L54>)
+### func \(SPF\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SPF.go#L72>)
 
 ```go
 func (r SPF) Type() string
@@ -1048,31 +1185,37 @@ func ToSRV(r Record) (SRV, error)
 func parseSRVData(data string) (SRV, error)
 ```
 
-### func \(SRV\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L85>)
+### func \(SRV\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L64>)
+
+```go
+func (r SRV) Equals(rx RecordX) bool
+```
+
+### func \(SRV\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L111>)
 
 ```go
 func (r SRV) GetID() (uint, bool)
 ```
 
-### func \(SRV\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L93>)
+### func \(SRV\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L119>)
 
 ```go
 func (r SRV) GetZoneID() uint
 ```
 
-### func \(SRV\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L78>)
+### func \(SRV\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L104>)
 
 ```go
 func (r SRV) Refs() map[string]string
 ```
 
-### func \(SRV\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L64>)
+### func \(SRV\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L90>)
 
 ```go
 func (r SRV) Serialise() map[string]string
 ```
 
-### func \(SRV\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L97>)
+### func \(SRV\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SRV.go#L123>)
 
 ```go
 func (r SRV) Type() string
@@ -1096,31 +1239,37 @@ type SSHFP struct {
 func ToSSHFP(r Record) SSHFP
 ```
 
-### func \(SSHFP\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L42>)
+### func \(SSHFP\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L23>)
+
+```go
+func (r SSHFP) Equals(rx RecordX) bool
+```
+
+### func \(SSHFP\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L60>)
 
 ```go
 func (r SSHFP) GetID() (uint, bool)
 ```
 
-### func \(SSHFP\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L50>)
+### func \(SSHFP\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L68>)
 
 ```go
 func (r SSHFP) GetZoneID() uint
 ```
 
-### func \(SSHFP\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L35>)
+### func \(SSHFP\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L53>)
 
 ```go
 func (r SSHFP) Refs() map[string]string
 ```
 
-### func \(SSHFP\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L23>)
+### func \(SSHFP\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L41>)
 
 ```go
 func (r SSHFP) Serialise() map[string]string
 ```
 
-### func \(SSHFP\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L54>)
+### func \(SSHFP\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_SSHFP.go#L72>)
 
 ```go
 func (r SSHFP) Type() string
@@ -1153,31 +1302,37 @@ type TXT struct {
 func ToTXT(r Record) TXT
 ```
 
-### func \(TXT\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L81>)
+### func \(TXT\) [Equals](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L61>)
+
+```go
+func (r TXT) Equals(rx RecordX) bool
+```
+
+### func \(TXT\) [GetID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L99>)
 
 ```go
 func (r TXT) GetID() (uint, bool)
 ```
 
-### func \(TXT\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L89>)
+### func \(TXT\) [GetZoneID](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L107>)
 
 ```go
 func (r TXT) GetZoneID() uint
 ```
 
-### func \(TXT\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L74>)
+### func \(TXT\) [Refs](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L92>)
 
 ```go
 func (r TXT) Refs() map[string]string
 ```
 
-### func \(TXT\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L61>)
+### func \(TXT\) [Serialise](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L79>)
 
 ```go
 func (r TXT) Serialise() map[string]string
 ```
 
-### func \(TXT\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L93>)
+### func \(TXT\) [Type](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/models/blob/master/client/models/record_TXT.go#L111>)
 
 ```go
 func (r TXT) Type() string

--- a/client/models/interface.go
+++ b/client/models/interface.go
@@ -1,6 +1,7 @@
 package models
 
 type RecordX interface {
+	Equals(RecordX) bool
 	GetID() (uint, bool)
 	GetZoneID() uint
 	Refs() map[string]string

--- a/client/models/record.go
+++ b/client/models/record.go
@@ -15,7 +15,7 @@ type Record struct {
 }
 
 func (r Record) ToX() (RecordX, error) {
-	switch strings.ToUpper(r.RecordType) {
+	switch r.Type() {
 	case "SOA":
 		return ToSOA(r)
 	case "A":
@@ -56,6 +56,18 @@ func (r Record) ToX() (RecordX, error) {
 	return nil, nil // This needs an error, whatever
 }
 
+func (r Record) Equals(rx RecordX) bool {
+	if rx == nil {
+		// pass
+	} else if rx.Type() != r.Type() {
+		// pass
+	} else if rec, err := r.ToX(); err == nil {
+		return rec.Equals(rx)
+	}
+
+	return false
+}
+
 func (r Record) Serialise() map[string]string {
 	if rx, err := r.ToX(); err == nil {
 		return rx.Serialise()
@@ -70,4 +82,20 @@ func (r Record) Refs() map[string]string {
 	}
 
 	return nil
+}
+
+func (r Record) GetID() (uint, bool) {
+	if r.ID == nil {
+		return 0, false
+	}
+
+	return *r.ID, true
+}
+
+func (r Record) GetZoneID() uint {
+	return r.ZoneID
+}
+
+func (r Record) Type() string {
+	return strings.ToUpper(r.RecordType)
 }

--- a/client/models/record_A.go
+++ b/client/models/record_A.go
@@ -22,6 +22,25 @@ func ToA(r Record) A {
 	}
 }
 
+func (r A) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "A" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToA(rec)
+	}
+
+	ra := rx.(A)
+
+	return r.ZoneID == ra.ZoneID &&
+		r.Domain == ra.Domain &&
+		r.TTL == ra.TTL &&
+		r.Data == ra.Data &&
+		r.Dynamic == ra.Dynamic
+}
+
 func (r A) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "a",

--- a/client/models/record_AAAA.go
+++ b/client/models/record_AAAA.go
@@ -22,6 +22,25 @@ func ToAAAA(r Record) AAAA {
 	}
 }
 
+func (r AAAA) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "AAAA" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToAAAA(rec)
+	}
+
+	raaaa := rx.(AAAA)
+
+	return r.ZoneID == raaaa.ZoneID &&
+		r.Domain == raaaa.Domain &&
+		r.TTL == raaaa.TTL &&
+		r.Data == raaaa.Data &&
+		r.Dynamic == raaaa.Dynamic
+}
+
 func (r AAAA) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "aaaa",

--- a/client/models/record_AFSDB.go
+++ b/client/models/record_AFSDB.go
@@ -20,6 +20,24 @@ func ToAFSDB(r Record) AFSDB {
 	}
 }
 
+func (r AFSDB) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "AFSDB" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToAFSDB(rec)
+	}
+
+	rafsdb := rx.(AFSDB)
+
+	return r.ZoneID == rafsdb.ZoneID &&
+		r.Domain == rafsdb.Domain &&
+		r.TTL == rafsdb.TTL &&
+		r.Data == rafsdb.Data
+}
+
 func (r AFSDB) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "AFSDB",

--- a/client/models/record_ALIAS.go
+++ b/client/models/record_ALIAS.go
@@ -20,6 +20,24 @@ func ToALIAS(r Record) ALIAS {
 	}
 }
 
+func (r ALIAS) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "ALIAS" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToALIAS(rec)
+	}
+
+	ralias := rx.(ALIAS)
+
+	return r.ZoneID == ralias.ZoneID &&
+		r.Domain == ralias.Domain &&
+		r.TTL == ralias.TTL &&
+		r.Data == ralias.Data
+}
+
 func (r ALIAS) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "ALIAS",

--- a/client/models/record_CAA.go
+++ b/client/models/record_CAA.go
@@ -20,6 +20,24 @@ func ToCAA(r Record) CAA {
 	}
 }
 
+func (r CAA) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "CAA" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToCAA(rec)
+	}
+
+	rcaa := rx.(CAA)
+
+	return r.ZoneID == rcaa.ZoneID &&
+		r.Domain == rcaa.Domain &&
+		r.TTL == rcaa.TTL &&
+		r.Data == rcaa.Data
+}
+
 func (r CAA) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "CAA",

--- a/client/models/record_CNAME.go
+++ b/client/models/record_CNAME.go
@@ -20,6 +20,24 @@ func ToCNAME(r Record) CNAME {
 	}
 }
 
+func (r CNAME) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "CNAME" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToCNAME(rec)
+	}
+
+	rcname := rx.(CNAME)
+
+	return r.ZoneID == rcname.ZoneID &&
+		r.Domain == rcname.Domain &&
+		r.TTL == rcname.TTL &&
+		r.Data == rcname.Data
+}
+
 func (r CNAME) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "CNAME",

--- a/client/models/record_HINFO.go
+++ b/client/models/record_HINFO.go
@@ -20,6 +20,24 @@ func ToHINFO(r Record) HINFO {
 	}
 }
 
+func (r HINFO) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "HINFO" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToHINFO(rec)
+	}
+
+	rhinfo := rx.(HINFO)
+
+	return r.ZoneID == rhinfo.ZoneID &&
+		r.Domain == rhinfo.Domain &&
+		r.TTL == rhinfo.TTL &&
+		r.Data == rhinfo.Data
+}
+
 func (r HINFO) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "HINFO",

--- a/client/models/record_LOC.go
+++ b/client/models/record_LOC.go
@@ -20,6 +20,24 @@ func ToLOC(r Record) LOC {
 	}
 }
 
+func (r LOC) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "LOC" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToLOC(rec)
+	}
+
+	rloc := rx.(LOC)
+
+	return r.ZoneID == rloc.ZoneID &&
+		r.Domain == rloc.Domain &&
+		r.TTL == rloc.TTL &&
+		r.Data == rloc.Data
+}
+
 func (r LOC) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "LOC",

--- a/client/models/record_MX.go
+++ b/client/models/record_MX.go
@@ -28,6 +28,30 @@ func ToMX(r Record) (MX, error) {
 	}, nil
 }
 
+func (r MX) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "MX" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		var err error
+		rx, err = ToMX(rec)
+
+		if err != nil {
+			return false
+		}
+	}
+
+	rmx := rx.(MX)
+
+	return r.ZoneID == rmx.ZoneID &&
+		r.Domain == rmx.Domain &&
+		r.TTL == rmx.TTL &&
+		r.Priority == rmx.Priority &&
+		r.Data == rmx.Data
+}
+
 func (r MX) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "MX",

--- a/client/models/record_NAPTR.go
+++ b/client/models/record_NAPTR.go
@@ -20,6 +20,24 @@ func ToNAPTR(r Record) NAPTR {
 	}
 }
 
+func (r NAPTR) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "NAPTR" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToNAPTR(rec)
+	}
+
+	rnaptr := rx.(NAPTR)
+
+	return r.ZoneID == rnaptr.ZoneID &&
+		r.Domain == rnaptr.Domain &&
+		r.TTL == rnaptr.TTL &&
+		r.Data == rnaptr.Data
+}
+
 func (r NAPTR) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "NAPTR",

--- a/client/models/record_NS.go
+++ b/client/models/record_NS.go
@@ -20,6 +20,24 @@ func ToNS(r Record) NS {
 	}
 }
 
+func (r NS) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "NS" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToNS(rec)
+	}
+
+	rns := rx.(NS)
+
+	return r.ZoneID == rns.ZoneID &&
+		r.Domain == rns.Domain &&
+		r.TTL == rns.TTL &&
+		r.Data == rns.Data
+}
+
 func (r NS) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "NS",

--- a/client/models/record_PTR.go
+++ b/client/models/record_PTR.go
@@ -20,6 +20,24 @@ func ToPTR(r Record) PTR {
 	}
 }
 
+func (r PTR) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "PTR" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToPTR(rec)
+	}
+
+	rptr := rx.(PTR)
+
+	return r.ZoneID == rptr.ZoneID &&
+		r.Domain == rptr.Domain &&
+		r.TTL == rptr.TTL &&
+		r.Data == rptr.Data
+}
+
 func (r PTR) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "PTR",

--- a/client/models/record_RP.go
+++ b/client/models/record_RP.go
@@ -20,6 +20,24 @@ func ToRP(r Record) RP {
 	}
 }
 
+func (r RP) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "RP" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToRP(rec)
+	}
+
+	rrp := rx.(RP)
+
+	return r.ZoneID == rrp.ZoneID &&
+		r.Domain == rrp.Domain &&
+		r.TTL == rrp.TTL &&
+		r.Data == rrp.Data
+}
+
 func (r RP) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "RP",

--- a/client/models/record_SOA.go
+++ b/client/models/record_SOA.go
@@ -62,6 +62,34 @@ func ToSOA(r Record) (SOA, error) {
 	}, nil
 }
 
+func (r SOA) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "SOA" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		var err error
+		rx, err = ToSOA(rec)
+
+		if err != nil {
+			return false
+		}
+	}
+
+	rsoa := rx.(SOA)
+
+	return r.ZoneID == rsoa.ZoneID &&
+		r.Domain == rsoa.Domain &&
+		r.TTL == rsoa.TTL &&
+		r.MName == rsoa.MName &&
+		r.RName == rsoa.RName &&
+		r.Serial == rsoa.Serial &&
+		r.Refresh == rsoa.Refresh &&
+		r.Retry == rsoa.Retry &&
+		r.Expire == rsoa.Expire
+}
+
 func (r SOA) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "SOA",

--- a/client/models/record_SPF.go
+++ b/client/models/record_SPF.go
@@ -20,6 +20,24 @@ func ToSPF(r Record) SPF {
 	}
 }
 
+func (r SPF) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "SPF" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToSPF(rec)
+	}
+
+	rspf := rx.(SPF)
+
+	return r.ZoneID == rspf.ZoneID &&
+		r.Domain == rspf.Domain &&
+		r.TTL == rspf.TTL &&
+		r.Data == rspf.Data
+}
+
 func (r SPF) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "SPF",

--- a/client/models/record_SRV.go
+++ b/client/models/record_SRV.go
@@ -61,6 +61,32 @@ func ToSRV(r Record) (SRV, error) {
 	}, nil
 }
 
+func (r SRV) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "SRV" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		var err error
+		rx, err = ToSRV(rec)
+
+		if err != nil {
+			return false
+		}
+	}
+
+	rsrv := rx.(SRV)
+
+	return r.ZoneID == rsrv.ZoneID &&
+		r.Domain == rsrv.Domain &&
+		r.TTL == rsrv.TTL &&
+		r.Priority == rsrv.Priority &&
+		r.Weight == rsrv.Weight &&
+		r.Port == rsrv.Port &&
+		r.Target == rsrv.Target
+}
+
 func (r SRV) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "SRV",

--- a/client/models/record_SSHFP.go
+++ b/client/models/record_SSHFP.go
@@ -20,6 +20,24 @@ func ToSSHFP(r Record) SSHFP {
 	}
 }
 
+func (r SSHFP) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "SSHFP" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToSSHFP(rec)
+	}
+
+	rsshfp := rx.(SSHFP)
+
+	return r.ZoneID == rsshfp.ZoneID &&
+		r.Domain == rsshfp.Domain &&
+		r.TTL == rsshfp.TTL &&
+		r.Data == rsshfp.Data
+}
+
 func (r SSHFP) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "SSHFP",

--- a/client/models/record_TXT.go
+++ b/client/models/record_TXT.go
@@ -58,6 +58,24 @@ func ToTXT(r Record) TXT {
 	}
 }
 
+func (r TXT) Equals(rx RecordX) bool {
+	if rx == nil {
+		return false
+	} else if rx.Type() != "TXT" {
+		return false
+	} else if rec, ok := rx.(Record); ok {
+		// Convert from Record
+		rx = ToTXT(rec)
+	}
+
+	rtxt := rx.(TXT)
+
+	return r.ZoneID == rtxt.ZoneID &&
+		r.Domain == rtxt.Domain &&
+		r.TTL == rtxt.TTL &&
+		r.Data == rtxt.Data
+}
+
 func (r TXT) Serialise() map[string]string {
 	return map[string]string{
 		"Type":                "TXT",

--- a/client/models/record_test.go
+++ b/client/models/record_test.go
@@ -20,7 +20,7 @@ var records_serial = map[string]int{
 	"CAA":   6,
 	"SRV":   9,
 	"TXT":   7,
-	"AFSDB": 7,
+	"AFSDB": 6,
 	"HINFO": 6,
 	"RP":    6,
 	"LOC":   6,
@@ -101,5 +101,32 @@ func TestRecord(t *testing.T) {
 
 		assert.Equal(t, record_out.Serialise(), record_in.Serialise(), record_in.RecordType)
 
+	}
+}
+
+func TestEqual(t *testing.T) {
+
+	for i, record_in := range records_in {
+		assert.False(t, record_in.Equals(nil), record_in.RecordType+"-nil")
+
+		for j, record_in2 := range records_in {
+			assert.Equal(t, i == j, record_in.Equals(record_in2), record_in.RecordType+"-"+record_in2.RecordType)
+			assert.Equal(t, i == j, record_in2.Equals(record_in), record_in2.RecordType+"-"+record_in.RecordType)
+		}
+	}
+
+	for i, record_out := range records_out {
+		assert.False(t, record_out.Equals(nil), record_out.Type()+"-nil")
+		for j, record2_out := range records_out {
+			assert.Equal(t, i == j, record_out.Equals(record2_out), record_out.Type()+"-"+record2_out.Type())
+			assert.Equal(t, i == j, record2_out.Equals(record_out), record2_out.Type()+"-"+record_out.Type())
+		}
+	}
+
+	for i, record_in := range records_in {
+		for j, record_out := range records_out {
+			assert.Equal(t, i == j, record_in.Equals(record_out), record_in.RecordType+"-"+record_out.Type())
+			assert.Equal(t, i == j, record_out.Equals(record_in), record_out.Type()+"-"+record_in.RecordType)
+		}
 	}
 }

--- a/internal/resources/AAAA_test.go
+++ b/internal/resources/AAAA_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestAccAAAARecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/AFSDB_test.go
+++ b/internal/resources/AFSDB_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccAFSDBRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/ALIAS_test.go
+++ b/internal/resources/ALIAS_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccALIASRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/A_test.go
+++ b/internal/resources/A_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestAccARecord(t *testing.T) {
+	t.Parallel()
+
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/CAA_test.go
+++ b/internal/resources/CAA_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccCAARecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/CNAME_test.go
+++ b/internal/resources/CNAME_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccCNAMERecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/HINFO_test.go
+++ b/internal/resources/HINFO_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccHINFORecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/LOC_test.go
+++ b/internal/resources/LOC_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccLOCRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/MX_test.go
+++ b/internal/resources/MX_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccMXRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/NAPTR_test.go
+++ b/internal/resources/NAPTR_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccNAPTRRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/NS_test.go
+++ b/internal/resources/NS_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccNSRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/PTR_test.go
+++ b/internal/resources/PTR_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccPTRRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/RP_test.go
+++ b/internal/resources/RP_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccRPRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/SPF_test.go
+++ b/internal/resources/SPF_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSPFRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/SRV_test.go
+++ b/internal/resources/SRV_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSRVRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/SSHFP_test.go
+++ b/internal/resources/SSHFP_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSSHFPRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/TXT_test.go
+++ b/internal/resources/TXT_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestAccTXTRecord(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]

--- a/internal/resources/ddns_key_test.go
+++ b/internal/resources/ddns_key_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestAccDDNSKey(t *testing.T) {
+	t.Parallel()
+	
 	domains := generateSubDomains("example-%04d.dns-he-net.eu.org", 9999, 2)
 	domainInit := domains[0]
 	domainUpdate := domains[1]


### PR DESCRIPTION
This PR handles (mostly) a race condition on the server side.

The service API has an incremental index that can be used to identify records.
The record with highest ID is latest created, always.

The response to a record creation contains the list of all existing records.
From those, the one with the highest ID is the one that was just created, as long as no other record is created at the same time.
As a result, and to ensure concurrency, we need to check the rest of the record attributes, which we know on advance.

This PR introduces the code required to compare records and find the matching one.

The solution is far from perfect. The server side is capable of handling requests with just the subdomain.
In that case, the resulting record will defer from the expected one and the matching will fail.

This is an initial approach. Suggestions are welcome, and locks on the server side appreciated.
