### PR TITLE
Force creation of session cookies before attempting authentication

### DIFF
--- a/client/client/README.md
+++ b/client/client/README.md
@@ -202,7 +202,7 @@ SetRecord creates or updates a record, then returns it, or an error.
 func (c *Client) authBasic(ctx context.Context, client *resty.Client) ([]*http.Cookie, error)
 ```
 
-### func \(\*Client\) [authOTP](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/client/blob/master/client/client/client_auth.go#L96>)
+### func \(\*Client\) [authOTP](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/client/blob/master/client/client/client_auth.go#L109>)
 
 ```go
 func (c *Client) authOTP(ctx context.Context, client *resty.Client) error
@@ -222,7 +222,7 @@ func (c *Client) autheticate(ctx context.Context) ([]*http.Cookie, error)
 
 autheticate authenticates the client against the API on a separated go\-resty client, then returns the cookies.
 
-### func \(\*Client\) [setAccount](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/client/blob/master/client/client/client_auth.go#L116>)
+### func \(\*Client\) [setAccount](<https://github.com/SuperBuker/terraform-provider-dns-he-net/tree/master/common/client/client/blob/master/client/client/client_auth.go#L129>)
 
 ```go
 func (c *Client) setAccount(resp *resty.Response)

--- a/client/client/client_auth.go
+++ b/client/client/client_auth.go
@@ -78,6 +78,12 @@ func (c *Client) autheticate(ctx context.Context) ([]*http.Cookie, error) {
 func (c *Client) authBasic(ctx context.Context, client *resty.Client) ([]*http.Cookie, error) {
 	c.log.Debug(ctx, "auth request - basic creds")
 
+	// Dummy request to initialise session and generate session cookies
+	respDummy, err := client.R().
+		SetContext(ctx).
+		Get(endpoint)
+	client.SetCookies(respDummy.Cookies());
+
 	resp, err := client.R().
 		SetContext(ctx).
 		SetFormData(authx.Creds(c.auth)).
@@ -90,7 +96,7 @@ func (c *Client) authBasic(ctx context.Context, client *resty.Client) ([]*http.C
 		return nil, err
 	}
 
-	return resp.Cookies(), err
+	return respDummy.Cookies(), err
 }
 
 func (c *Client) authOTP(ctx context.Context, client *resty.Client) error {


### PR DESCRIPTION
For some reason the dns.he.net API does not seem to set a session cookie when the very first request is already the login POST.

This commit adds a dummy GET request to the main URL to force creating a session.  It then returns _that_ session cookies after the authentication credentials have been POSTed.

Without this fix, I was unable to use this provider, as it always resulted in a "not authenticated" error (even after the initial authentication POST was successful).  With some debugging I was able to trace this down to an empty `cookies` list and came up with this solution.

PS: Thanks a lot for putting in the work creating this provider!