### PR TITLE
Account id test fix

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -64,6 +64,7 @@ jobs:
         DNSHENET_USER: ${{ secrets.DNSHENET_USER }}
         DNSHENET_PASSWD: ${{ secrets.DNSHENET_PASSWD }}
         DNSHENET_OTP: ${{ secrets.DNSHENET_OTP }}
+        DNSHENET_ACCOUNTID: ${{ secrets.DNSHENET_ACCOUNTID }}
         TF_ACC: "1"
       run: |
         go test -v  ./... -covermode count -coverprofile coverage.out -json > TestResults-${{ matrix.go-version }}-${{ matrix.terraform-version }}.json || true

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ $ go build -o terraform-provider-dns-he-net
 
 In order to run the full suite of Acceptance tests, the following environment variables must be set:
 
-- `DNSHENET_USER`
-- `DNSHENET_PASSWD`
-- `DNSHENET_OTP`
+- `DNSHENET_USER` (mandatory)
+- `DNSHENET_PASSWD` (mandatory)
+- `DNSHENET_OTP` (optional, only required if the OTP auth is enabled)
+- `DNSHENET_ACCOUNT_ID` (mandatory, used for validating the testing results)
 
 ```sh
 $ TF_ACC=1 go test -v ./...

--- a/client/client/client_test.go
+++ b/client/client/client_test.go
@@ -18,6 +18,7 @@ func TestClientAuth(t *testing.T) {
 	user := os.Getenv("DNSHENET_USER")
 	password := os.Getenv("DNSHENET_PASSWD")
 	otp := os.Getenv("DNSHENET_OTP")
+	accountID := os.Getenv("DNSHENET_ACCOUNT_ID")
 
 	t.Run("Client auth.Simple", func(t *testing.T) {
 		authObj, err := auth.NewAuth(user, password, otp, auth.Simple)
@@ -26,7 +27,7 @@ func TestClientAuth(t *testing.T) {
 		cli, err := NewClient(context.TODO(), authObj, logging.NewZerolog(zerolog.DebugLevel, false))
 		require.NoError(t, err)
 
-		assert.Equal(t, "v6643873d8c41428.97783691", cli.GetAccount())
+		assert.Equal(t, accountID, cli.GetAccount())
 
 		for _, cookie := range cli.client.Cookies {
 			cookie.Value = "" // clear cookie value
@@ -41,7 +42,7 @@ func TestClientAuth(t *testing.T) {
 
 		assert.Equal(t, 3, len(zones))
 
-		assert.Equal(t, "v6643873d8c41428.97783691", cli.GetAccount())
+		assert.Equal(t, accountID, cli.GetAccount())
 
 		// Not onboarded record
 		records, err := cli.GetRecords(context.TODO(), 1096291)
@@ -64,7 +65,7 @@ func TestClientAuth(t *testing.T) {
 
 		assert.Equal(t, "user-agent test", cli.client.Header.Get("User-Agent"))
 
-		assert.Equal(t, "v6643873d8c41428.97783691", cli.GetAccount())
+		assert.Equal(t, accountID, cli.GetAccount())
 
 		zones, err := cli.GetZones(context.TODO())
 		require.NoError(t, err)

--- a/internal/datasources/account_test.go
+++ b/internal/datasources/account_test.go
@@ -1,6 +1,7 @@
 package datasources_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/SuperBuker/terraform-provider-dns-he-net/internal/test_utils"
@@ -9,6 +10,8 @@ import (
 )
 
 func TestAccAccount(t *testing.T) {
+	accountID := os.Getenv("DNSHENET_ACCOUNT_ID")
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: test_utils.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -17,7 +20,7 @@ func TestAccAccount(t *testing.T) {
 				Config: test_utils.ProviderConfig + `data "dns-he-net_account" "test" {}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify record attibutes
-					resource.TestCheckResourceAttr("data.dns-he-net_account.test", "id", "v6643873d8c41428.97783691"),
+					resource.TestCheckResourceAttr("data.dns-he-net_account.test", "id", accountID),
 				),
 			},
 		},

--- a/internal/datasources/zones_test.go
+++ b/internal/datasources/zones_test.go
@@ -1,6 +1,7 @@
 package datasources_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/SuperBuker/terraform-provider-dns-he-net/internal/test_utils"
@@ -10,6 +11,7 @@ import (
 
 func TestAccZones(t *testing.T) {
 	t.Parallel()
+	accountID := os.Getenv("DNSHENET_ACCOUNT_ID")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: test_utils.TestAccProtoV6ProviderFactories,
@@ -23,7 +25,7 @@ func TestAccZones(t *testing.T) {
 					resource.TestCheckResourceAttr("data.dns-he-net_zones.example", "zones.#", "3"),
 
 					// Verify placeholder attributes
-					resource.TestCheckResourceAttr("data.dns-he-net_zones.example", "id", "v6643873d8c41428.97783691"),
+					resource.TestCheckResourceAttr("data.dns-he-net_zones.example", "id", accountID),
 				),
 			},
 		},

--- a/internal/resources/AAAA_test.go
+++ b/internal/resources/AAAA_test.go
@@ -115,6 +115,7 @@ func TestAccAAAARecord(t *testing.T) {
 					user := os.Getenv("DNSHENET_USER")
 					password_ := os.Getenv("DNSHENET_PASSWD")
 					otp := os.Getenv("DNSHENET_OTP")
+					accountID := os.Getenv("DNSHENET_ACCOUNT_ID")
 
 					authObj, err := auth.NewAuth(user, password_, otp, auth.Simple)
 					require.NoError(t, err)
@@ -122,7 +123,7 @@ func TestAccAAAARecord(t *testing.T) {
 					cli, err := client.NewClient(context.TODO(), authObj, logging.NewZerolog(zerolog.DebugLevel, false))
 					require.NoError(t, err)
 
-					assert.Equal(t, "v6643873d8c41428.97783691", cli.GetAccount())
+					assert.Equal(t, accountID, cli.GetAccount())
 
 					ok, err := cli.DDNS().UpdateIP(context.TODO(), domainUpdate, password, "::2")
 					require.NoError(t, err)

--- a/internal/resources/A_test.go
+++ b/internal/resources/A_test.go
@@ -115,6 +115,7 @@ func TestAccARecord(t *testing.T) {
 					user := os.Getenv("DNSHENET_USER")
 					password_ := os.Getenv("DNSHENET_PASSWD")
 					otp := os.Getenv("DNSHENET_OTP")
+					accountID := os.Getenv("DNSHENET_ACCOUNT_ID")
 
 					authObj, err := auth.NewAuth(user, password_, otp, auth.Simple)
 					require.NoError(t, err)
@@ -122,7 +123,7 @@ func TestAccARecord(t *testing.T) {
 					cli, err := client.NewClient(context.TODO(), authObj, logging.NewZerolog(zerolog.DebugLevel, false))
 					require.NoError(t, err)
 
-					assert.Equal(t, "v6643873d8c41428.97783691", cli.GetAccount())
+					assert.Equal(t, accountID, cli.GetAccount())
 
 					ok, err := cli.DDNS().UpdateIP(context.TODO(), domainUpdate, password, "10.2.3.4")
 					require.NoError(t, err)

--- a/internal/resources/TXT_test.go
+++ b/internal/resources/TXT_test.go
@@ -118,6 +118,7 @@ func TestAccTXTRecord(t *testing.T) {
 					user := os.Getenv("DNSHENET_USER")
 					password_ := os.Getenv("DNSHENET_PASSWD")
 					otp := os.Getenv("DNSHENET_OTP")
+					accountID := os.Getenv("DNSHENET_ACCOUNT_ID")
 
 					authObj, err := auth.NewAuth(user, password_, otp, auth.Simple)
 					require.NoError(t, err)
@@ -125,7 +126,7 @@ func TestAccTXTRecord(t *testing.T) {
 					cli, err := client.NewClient(context.TODO(), authObj, logging.NewZerolog(zerolog.DebugLevel, false))
 					require.NoError(t, err)
 
-					assert.Equal(t, "v6643873d8c41428.97783691", cli.GetAccount())
+					assert.Equal(t, accountID, cli.GetAccount())
 
 					ok, err := cli.DDNS().UpdateTXT(context.TODO(), domainUpdate, password, data2[1:len(data2)-1])
 					require.NoError(t, err)

--- a/internal/resources/ddns_key_test.go
+++ b/internal/resources/ddns_key_test.go
@@ -52,6 +52,7 @@ func TestAccDDNSKey(t *testing.T) {
 					user := os.Getenv("DNSHENET_USER")
 					password := os.Getenv("DNSHENET_PASSWD")
 					otp := os.Getenv("DNSHENET_OTP")
+					accountID := os.Getenv("DNSHENET_ACCOUNT_ID")
 
 					authObj, err := auth.NewAuth(user, password, otp, auth.Simple)
 					require.NoError(t, err)
@@ -59,7 +60,7 @@ func TestAccDDNSKey(t *testing.T) {
 					cli, err := client.NewClient(context.TODO(), authObj, logging.NewZerolog(zerolog.DebugLevel, false))
 					require.NoError(t, err)
 
-					assert.Equal(t, "v6643873d8c41428.97783691", cli.GetAccount())
+					assert.Equal(t, accountID, cli.GetAccount())
 
 					// Makes auth fail when validating the expected key, triggering an update
 					anotherPassword := randStringBytesMaskImprSrcSB(16)


### PR DESCRIPTION
Removes hardcoded account ID in tests.
The value is now provided as a environmental variable.
Tests, documentation and CI/CD have been updated accordingly.