### PR TITLE
DDNSKey unknown current state fix

### DIFF
--- a/internal/resources/ddns_key.go
+++ b/internal/resources/ddns_key.go
@@ -181,7 +181,7 @@ func (dk ddnsKey) Read(ctx context.Context, req resource.ReadRequest, resp *reso
 		)
 		return
 	} else if !ok {
-		state.Key = types.StringUnknown()
+		state.Key = types.StringNull()
 	}
 
 	// Set state


### PR DESCRIPTION
After clarification from the Terraform team on the failure appearing on the `terraform-plugin-testing@v1.6.0`, it seems the unknown state is forbidden. In fact, the plan state fails to be printed if used.
They've kindly suggested to use null as a replacement if the value is indeed unkown, which works.

More info can be found in https://github.com/hashicorp/terraform-plugin-testing/issues/262.