### PR TITLE
Fix SRV record validator to allow services such as XMPP

### DIFF
--- a/internal/resources/README.md
+++ b/internal/resources/README.md
@@ -470,7 +470,7 @@ var srvDomainValidator = stringvalidator.RegexMatches(srvRegexp, "value must be 
 ```
 
 ```go
-var srvRegexp = regexp.MustCompile(`^_[a-zA-Z0-9]+\._(?:tcp|udp)\.(?:[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]\.)+[a-zA-Z]{2,}$`)
+var srvRegexp = regexp.MustCompile(`^_[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?\._(?:tcp|udp)\.(?:[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]\.)+[a-zA-Z]{2,}$`)
 ```
 
 ```go

--- a/internal/resources/utils.go
+++ b/internal/resources/utils.go
@@ -39,7 +39,7 @@ var rpRegexp = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-\_]{0,61}[a-zA-
 var rpValidator = stringvalidator.RegexMatches(rpRegexp, "value must be a valid RP record")
 var spfRegexp = regexp.MustCompile(`^"v=spf1 .+"$`)
 var spfValidator = stringvalidator.RegexMatches(spfRegexp, "value must be a valid SPF record")
-var srvRegexp = regexp.MustCompile(`^_[a-zA-Z0-9]+\._(?:tcp|udp)\.(?:[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]\.)+[a-zA-Z]{2,}$`)
+var srvRegexp = regexp.MustCompile(`^_[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?\._(?:tcp|udp)\.(?:[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]\.)+[a-zA-Z]{2,}$`)
 var srvDomainValidator = stringvalidator.RegexMatches(srvRegexp, "value must be a valid SRV domain name")
 var sshfpRegexp = regexp.MustCompile(`^[12346] [12] [a-fA-F0-9]+$`) // Case insensitive ¯\_(ツ)_/¯
 var sshfpValidator = stringvalidator.RegexMatches(sshfpRegexp, "value must be a valid SSHFP record")

--- a/internal/resources/validators_test.go
+++ b/internal/resources/validators_test.go
@@ -33,6 +33,8 @@ func TestValidators(t *testing.T) {
 
 	assert.True(t, srvRegexp.MatchString("_sip._tcp.example.com"))
 
+	assert.True(t, srvRegexp.MatchString("_xmpp-server._tcp.example.com"))
+
 	assert.True(t, sshfpRegexp.MatchString("1 1 123456789abcdef67890123456789abcdef67890"))
 
 	assert.True(t, txtRegexp.MatchString(`"hello world"`))


### PR DESCRIPTION
Fixes https://github.com/SuperBuker/terraform-provider-dns-he-net/issues/140

Adds test with a normal XMPP SRV record name